### PR TITLE
Added unicode_literasl to all files to avoid unicode errors

### DIFF
--- a/address/__init__.py
+++ b/address/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/address/admin.py
+++ b/address/admin.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from address.models import *

--- a/address/forms.py
+++ b/address/forms.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from django import forms
 # from uni_form.helpers import *
 from django.utils.safestring import mark_safe

--- a/address/models.py
+++ b/address/models.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from django.db import models
 from django.core.exceptions import ValidationError
 from django.db.models.fields.related import ForeignObject

--- a/address/tests/__init__.py
+++ b/address/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals


### PR DESCRIPTION
When adding some Entities(like España as country) in some languages the plugin did Unicode errors. I have added to all py files:
```
# -*- coding: utf-8 -*-
from __future__ import unicode_literal
```